### PR TITLE
U-blox GPS receivers different format for time

### DIFF
--- a/gps.js
+++ b/gps.js
@@ -84,7 +84,15 @@
     ret.setUTCHours(time.slice(0, 2));
     ret.setUTCMinutes(time.slice(2, 4));
     ret.setUTCSeconds(time.slice(4, 6));
-    ret.setUTCMilliseconds(parseFloat(time.slice(7)) || 0);
+    
+    // Extract the milliseconds, since they can be not present, be 3 decimal place, or 2 decimal places, or other?
+    var msStr = time.slice(7);
+    var msExp = msStr.length;
+    var ms = 0;
+    if (msExp !== 0) {
+        ms = parseFloat(msStr) * Math.pow(10, 3 - msExp);
+    }
+    ret.setUTCMilliseconds(ms);
 
     return ret;
   }

--- a/tests/parser.js
+++ b/tests/parser.js
@@ -434,6 +434,21 @@ var tests = {
     'time': new Date(today + 'T22:54:44.000Z'),
     'type': 'GLL',
     'valid': true
+  },
+  '$GPGGA,174815.40,4141.46474,N,00849.77225,W,1,08,1.24,11.8,M,50.5,M,,*76': {
+    'age': null,
+    'alt': 11.8,
+    'geoidal': 50.5,
+    'hdop': 1.24,
+    'quality': 'fix',
+    'satelites': 8,
+    'stationID': null,
+    'lat': 41.691079,
+    'lon': -8.8295375,
+    'time': new Date('2016-09-03T17:48:15.400Z'),
+    'raw': '$GPGGA,174815.40,4141.46474,N,00849.77225,W,1,08,1.24,11.8,M,50.5,M,,*76',
+    'type': 'GGA',
+    'valid': true,
   }
 };
 var collect = {};


### PR DESCRIPTION
U-blox GPS receivers have only 2 decimal places to hold the millisecond value. Fixed to accommodate this.

Updated `parseTime()` and added a test to test it.