### PR TITLE
recover partial updates from an invalid message

### DIFF
--- a/gps.js
+++ b/gps.js
@@ -862,7 +862,12 @@
       var line = this['partial'].slice(0, pos);
 
       if (line.charAt(0) === '$') {
-        this['update'](line);
+        try {
+          this['update'](line);
+        } catch (err) {
+          this['partial'] = "";
+          throw new Error(err);
+        }
       }
       this['partial'] = this['partial'].slice(pos + 2);
     }


### PR DESCRIPTION
catches any errors so the partial update cache can be reset before re-throwing the error
this allows subsequent (valid) messages to parse as expected